### PR TITLE
Set milliseconds to zero too

### DIFF
--- a/src/main/java/com/luckycatlabs/sunrisesunset/calculator/SolarEventCalculator.java
+++ b/src/main/java/com/luckycatlabs/sunrisesunset/calculator/SolarEventCalculator.java
@@ -360,6 +360,7 @@ public class SolarEventCalculator {
         resultTime.set(Calendar.HOUR_OF_DAY, hour);
         resultTime.set(Calendar.MINUTE, minutes.intValue());
         resultTime.set(Calendar.SECOND, 0);
+        resultTime.set(Calendar.MILLISECOND, 0);
         resultTime.setTimeZone(date.getTimeZone());
 
         return resultTime;


### PR DESCRIPTION
The code explicitly sets seconds to zero but leaves milliseconds. Since the result depends on current time, this may cause changes in milliseconds of calculated time which could leave to strange results (for example calculating time of next sunset immediately after sunset could give a new value which is after current time).

The simple change is to set milliseconds to zero too.
