### PR TITLE
Invalid sunset date when sunset is after midnight

### DIFF
--- a/src/main/java/com/luckycatlabs/sunrisesunset/calculator/SolarEventCalculator.java
+++ b/src/main/java/com/luckycatlabs/sunrisesunset/calculator/SolarEventCalculator.java
@@ -283,9 +283,6 @@ public class SolarEventCalculator {
         if (timeZone.inDaylightTime(date.getTime())) {
             localTime = localTime.add(BigDecimal.ONE);
         }
-        if (localTime.doubleValue() > 24.0) {
-            localTime = localTime.subtract(BigDecimal.valueOf(24));
-        }
         return localTime;
     }
 


### PR DESCRIPTION
Quite a specific situation: Reykjavik sunset on summer solstice is at about 00:04.

I am expecting that if I'm trying to calculate sunrise and sunset time for a timestamp which is day time, i'll get a _this_ day sunrise and _this_ day sunset. However the result is off by 24 hours.
