### PR TITLE
adjustForDST to respect getDSTSavings

### DIFF
--- a/src/main/java/com/luckycatlabs/sunrisesunset/calculator/SolarEventCalculator.java
+++ b/src/main/java/com/luckycatlabs/sunrisesunset/calculator/SolarEventCalculator.java
@@ -282,7 +282,9 @@ public class SolarEventCalculator {
     private BigDecimal adjustForDST(BigDecimal localMeanTime, Calendar date) {
         BigDecimal localTime = localMeanTime;
         if (timeZone.inDaylightTime(date.getTime())) {
-            localTime = localTime.add(BigDecimal.ONE);
+            double millisToHours = 1.0 / (1000 * 60 * 60);
+            double dstHours = timeZone.getDSTSavings() * millisToHours;
+            localTime = localTime.add(BigDecimal.valueOf(dstHours));
         }
         if (localTime.doubleValue() > 24.0) {
             localTime = localTime.subtract(BigDecimal.valueOf(24));

--- a/src/main/java/com/luckycatlabs/sunrisesunset/calculator/SolarEventCalculator.java
+++ b/src/main/java/com/luckycatlabs/sunrisesunset/calculator/SolarEventCalculator.java
@@ -283,7 +283,8 @@ public class SolarEventCalculator {
         BigDecimal localTime = localMeanTime;
         if (timeZone.inDaylightTime(date.getTime())) {
             double millisToHours = 1.0 / (1000 * 60 * 60);
-            double dstHours = timeZone.getDSTSavings() * millisToHours;
+            //double dstHours = timeZone.getDSTSavings() * millisToHours;
+            double dstHours = (timeZone.getOffset(date.getTimeInMillis()) - timeZone.getRawOffset()) * millisToHours;
             localTime = localTime.add(BigDecimal.valueOf(dstHours));
         }
         if (localTime.doubleValue() > 24.0) {


### PR DESCRIPTION
contains both potential fixes described in #18
1. dst offset of `getDSTSavings`
2. dst offset of `date.getTimeInMillis()) - timeZone.getRawOffset()`
