### PR TITLE
Improve Performance by Avoiding Recalculating Constants

### DIFF
--- a/src/main/java/com/luckycatlabs/sunrisesunset/calculator/SolarEventCalculator.java
+++ b/src/main/java/com/luckycatlabs/sunrisesunset/calculator/SolarEventCalculator.java
@@ -29,6 +29,9 @@ import com.luckycatlabs.sunrisesunset.dto.Location;
  * Parent class of the Sunrise and Sunset calculator classes.
  */
 public class SolarEventCalculator {
+    public static final BigDecimal RADIANS_TO_DEGREES_MULTIPLIER = new BigDecimal(180 / Math.PI);
+    public static final BigDecimal DEGREES_TO_RADIANS_MULTIPLIER = BigDecimal.valueOf(Math.PI / 180.0);
+    public static final BigDecimal HOURS_IN_DAY = BigDecimal.valueOf(24.0D);
     final private Location location;
     final private TimeZone timeZone;
 
@@ -304,7 +307,7 @@ public class SolarEventCalculator {
 
         BigDecimal localTime = localTimeParam;
         if (localTime.compareTo(BigDecimal.ZERO) == -1) {
-            localTime = localTime.add(BigDecimal.valueOf(24.0D));
+            localTime = localTime.add(HOURS_IN_DAY);
         }
         String[] timeComponents = localTime.toPlainString().split("\\.");
         int hour = Integer.parseInt(timeComponents[0]);
@@ -341,7 +344,7 @@ public class SolarEventCalculator {
 
         BigDecimal localTime = localTimeParam;
         if (localTime.compareTo(BigDecimal.ZERO) == -1) {
-            localTime = localTime.add(BigDecimal.valueOf(24.0D));
+            localTime = localTime.add(HOURS_IN_DAY);
             resultTime.add(Calendar.HOUR_OF_DAY, -24);
         }
         String[] timeComponents = localTime.toPlainString().split("\\.");
@@ -385,11 +388,11 @@ public class SolarEventCalculator {
     }
 
     private BigDecimal convertRadiansToDegrees(BigDecimal radians) {
-        return multiplyBy(radians, new BigDecimal(180 / Math.PI));
+        return multiplyBy(radians, RADIANS_TO_DEGREES_MULTIPLIER);
     }
 
     private BigDecimal convertDegreesToRadians(BigDecimal degrees) {
-        return multiplyBy(degrees, BigDecimal.valueOf(Math.PI / 180.0));
+        return multiplyBy(degrees, DEGREES_TO_RADIANS_MULTIPLIER);
     }
 
     private BigDecimal multiplyBy(BigDecimal multiplicand, BigDecimal multiplier) {


### PR DESCRIPTION
In `convertRadiansToDegrees` and `convertDegreesToRadians` methods, we are creating `BigDecimal`s of `PI/180` and `180/PI`. These values have high precision and BigDecimal is too slow. We move these into a static variable to avoid repeated creations.

This change nets us about 50-66% speedup. The following table contains the testing on my machine.
Index | Total Operations(ops) | Total Time(s) | Speed(ops/s) | Speedup
-- | --: | --: | --: | --:
Default | 5,000,000 | 92 | 5.43E+04 | 1.00
Moved to Static Variables | 5,000,000 | 55 | 9.09E+04 | 1.67
