### PR TITLE
Fix adjustForDST to use actual DST savings

### DIFF
--- a/src/main/java/com/luckycatlabs/sunrisesunset/calculator/SolarEventCalculator.java
+++ b/src/main/java/com/luckycatlabs/sunrisesunset/calculator/SolarEventCalculator.java
@@ -282,7 +282,9 @@ public class SolarEventCalculator {
     private BigDecimal adjustForDST(BigDecimal localMeanTime, Calendar date) {
         BigDecimal localTime = localMeanTime;
         if (timeZone.inDaylightTime(date.getTime())) {
-            localTime = localTime.add(BigDecimal.ONE);
+            long dstMillis = timeZone.getOffset(date.getTimeInMillis()) - timeZone.getRawOffset();
+            BigDecimal dstSavings = divideBy(BigDecimal.valueOf(dstMillis), BigDecimal.valueOf(3600000));
+            localTime = localTime.add(dstSavings);
         }
         if (localTime.doubleValue() > 24.0) {
             localTime = localTime.subtract(BigDecimal.valueOf(24));

--- a/src/test/java/com/luckycatlabs/sunrisesunset/calculator/SolarEventCalculatorTest.java
+++ b/src/test/java/com/luckycatlabs/sunrisesunset/calculator/SolarEventCalculatorTest.java
@@ -69,4 +69,13 @@ public class SolarEventCalculatorTest extends BaseTestCase {
         assertEquals(14, localTime.get(Calendar.HOUR_OF_DAY));
         assertEquals(0, localTime.get(Calendar.MINUTE));
     }
+
+    @Test
+    public void testAdjustForDST() {
+        // Antarctica/Troll: standard UTC+0, DST UTC+2 (savings = +2 h).
+        super.setup(Calendar.APRIL, 1, 2024, "-72.0117", "2.5350", "Antarctica/Troll");
+        SolarEventCalculator trollCalc = new SolarEventCalculator(location, "Antarctica/Troll");
+        assertEquals("08:43", trollCalc.computeSunriseTime(Zenith.OFFICIAL, eventDate));
+        assertEquals("19:02", trollCalc.computeSunsetTime(Zenith.OFFICIAL, eventDate));
+    }
 }


### PR DESCRIPTION
SolarEventCalculator.adjustForDST() always adds 1 hour during DST, but some timezones have different DST savings (for example, 2 hours in Antarctica/Troll, or 30 minutes in Australia/Lord_Howe).

Also, some timezones have changed their DST rules historically. So, compute DST savings as:

    TimeZone.getOffset(millis) - TimeZone.getRawOffset()

which returns the actual value for the given timestamp, instead of TimeZone.getDSTSavings(), which would return the timezone's "current" or "default" DST savings.

Fixes: #18