### PR TITLE
Fix sign error in getSunrise / getSunset methods

### DIFF
--- a/src/main/java/com/luckycatlabs/sunrisesunset/SunriseSunsetCalculator.java
+++ b/src/main/java/com/luckycatlabs/sunrisesunset/SunriseSunsetCalculator.java
@@ -255,7 +255,7 @@ public class SunriseSunsetCalculator {
 
     public static Calendar getSunrise(double latitude, double longitude, TimeZone timeZone, Calendar date, double degrees) {
         SolarEventCalculator solarEventCalculator = new SolarEventCalculator(new Location(latitude, longitude), timeZone);
-        return solarEventCalculator.computeSunriseCalendar(new Zenith(90 - degrees), date);
+        return solarEventCalculator.computeSunriseCalendar(new Zenith(90 + degrees), date);
     }
 
     /**
@@ -276,7 +276,7 @@ public class SunriseSunsetCalculator {
 
     public static Calendar getSunset(double latitude, double longitude, TimeZone timeZone, Calendar date, double degrees) {
         SolarEventCalculator solarEventCalculator = new SolarEventCalculator(new Location(latitude, longitude), timeZone);
-        return solarEventCalculator.computeSunsetCalendar(new Zenith(90 - degrees), date);
+        return solarEventCalculator.computeSunsetCalendar(new Zenith(90 + degrees), date);
     }
 
     /**

--- a/src/test/java/com/luckycatlabs/sunrisesunset/SunriseSunsetCalculatorTest.java
+++ b/src/test/java/com/luckycatlabs/sunrisesunset/SunriseSunsetCalculatorTest.java
@@ -19,6 +19,7 @@ package com.luckycatlabs.sunrisesunset;
 import static org.junit.Assert.assertEquals;
 
 import java.util.Calendar;
+import java.util.TimeZone;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -78,6 +79,35 @@ public class SunriseSunsetCalculatorTest extends BaseTestCase {
     @Test
     public void testComputeOfficialSunset() {
         assertTimeEquals("18:00", calc.getOfficialSunsetForDate(eventDate), eventDate.getTime().toString());
+    }
+
+    @Test
+    public void testComputeSunriseArbitraryDegrees() {
+        TimeZone tz = TimeZone.getTimeZone("America/New_York");
+
+        assertHourMinuteEquals(calc.getCivilSunriseCalendarForDate(eventDate),
+                SunriseSunsetCalculator.getSunrise(39.9937, -75.7850, tz, eventDate, 6.0));
+        assertHourMinuteEquals(calc.getNauticalSunriseCalendarForDate(eventDate),
+                SunriseSunsetCalculator.getSunrise(39.9937, -75.7850, tz, eventDate, 12.0));
+        assertHourMinuteEquals(calc.getAstronomicalSunriseCalendarForDate(eventDate),
+                SunriseSunsetCalculator.getSunrise(39.9937, -75.7850, tz, eventDate, 18.0));
+    }
+
+    @Test
+    public void testComputeSunsetArbitraryDegrees() {
+        TimeZone tz = TimeZone.getTimeZone("America/New_York");
+
+        assertHourMinuteEquals(calc.getCivilSunsetCalendarForDate(eventDate),
+                SunriseSunsetCalculator.getSunset(39.9937, -75.7850, tz, eventDate, 6.0));
+        assertHourMinuteEquals(calc.getNauticalSunsetCalendarForDate(eventDate),
+                SunriseSunsetCalculator.getSunset(39.9937, -75.7850, tz, eventDate, 12.0));
+        assertHourMinuteEquals(calc.getAstronomicalSunsetCalendarForDate(eventDate),
+                SunriseSunsetCalculator.getSunset(39.9937, -75.7850, tz, eventDate, 18.0));
+    }
+
+    private static void assertHourMinuteEquals(Calendar expected, Calendar actual) {
+        assertEquals(expected.get(Calendar.HOUR_OF_DAY), actual.get(Calendar.HOUR_OF_DAY));
+        assertEquals(expected.get(Calendar.MINUTE), actual.get(Calendar.MINUTE));
     }
 
     @Test


### PR DESCRIPTION
SunriseSunsetCalculator.getSunrise(...) accepts a "degrees below the horizon" parameter, which corresponds to a solar zenith angle of 90 + X degrees.

However, the implementation used the opposite sign to construct the Zenith instance, so a caller would get the time at which the sun reaches X degrees *above* the horizon, not below. The same problem is also present in the getSunset(...) method.

Fix both by flipping the sign:

    new Zenith(90 - degrees) -> new Zenith(90 + degrees)

Fixes: #50